### PR TITLE
Osiris accept multiple schemas and exposes endpoint for logs

### DIFF
--- a/osiris/aggregator.py
+++ b/osiris/aggregator.py
@@ -13,10 +13,6 @@ from thoth.storages.result_base import ResultStorageBase
 from osiris import DEFAULT_OC_LOG_LEVEL
 from osiris import get_oc_client
 
-from osiris.exceptions import OCError
-from osiris.exceptions import OCAuthenticationError
-from osiris.utils import execute_command
-
 from osiris.schema.build import BuildLog
 from osiris.schema.build import BuildInfo, BuildInfoSchema
 from osiris.schema.build import BuildInfoPagination
@@ -86,7 +82,13 @@ class _BuildLogsAggregator(ResultStorageBase):
         document_id: str = hashlib.sha256(build_id.encode('utf-8')).hexdigest()
 
         build_doc: dict = self.ceph.retrieve_document(document_id)
-        build_log = BuildLog(raw=build_doc.pop('build_log'))
+
+        build_log_data = build_doc.pop('build_log')
+
+        if isinstance(build_log_data, dict):
+            build_log = BuildLog(**build_log_data)
+        else:
+            build_log = BuildLog(raw=build_log_data)
 
         ret: tuple = (build_log, )
 

--- a/osiris/aggregator.py
+++ b/osiris/aggregator.py
@@ -88,12 +88,12 @@ class _BuildLogsAggregator(ResultStorageBase):
         if isinstance(build_log_data, dict):
             build_log = BuildLog(**build_log_data)
         else:
-            build_log = BuildLog(raw=build_log_data)
+            build_log = BuildLog(data=build_log_data)
 
         ret: tuple = (build_log, )
 
         if not log_only:
-            build_info, _ = BuildInfoSchema().load(build_doc)
+            build_info = BuildInfo(**BuildInfoSchema().load(build_doc).data)
 
             ret = build_log, build_info
 

--- a/osiris/apis/config.py
+++ b/osiris/apis/config.py
@@ -1,6 +1,6 @@
 # Osiris: Build log aggregator.
 
-"""Namespace: auth"""
+"""Namespace: auth."""
 
 from http import HTTPStatus
 from pathlib import Path

--- a/osiris/response.py
+++ b/osiris/response.py
@@ -19,7 +19,6 @@ def status(http_status: HTTPStatus):
     This decorator can be used to assemble custom payloads
     with default keys common to all responses.
     """
-
     def wrapper(fun: typing.Callable[..., dict] = None):
 
         def inner(*args, **kwargs) -> typing.Tuple[dict, HTTPStatus]:

--- a/osiris/schema/base.py
+++ b/osiris/schema/base.py
@@ -67,7 +67,7 @@ class Base(object):
 
 class BaseSchema(Schema):
     """Base model schema.
-    
+
     This schema is inhereted and marshalled by all schemas
     and used for each API payload.
     """

--- a/osiris/schema/build.py
+++ b/osiris/schema/build.py
@@ -15,15 +15,6 @@ from osiris.schema.ocp import OCP, OCPSchema
 from kubernetes.client.models.v1_event import V1Event as Event
 
 
-class BuildLog(object):
-    """BuildLog model."""
-
-    def __init__(self, raw: str):
-        """Initialize BuildLog model."""
-
-        self.data = raw
-
-
 class BuildInfo(object):
     """BuildInfo model."""
 
@@ -69,6 +60,15 @@ class BuildInfo(object):
         
         Failed builds are considered completed, too."""
         return self.build_status == 'BuildCompleted' or self.build_status == 'BuildFailed'
+
+
+class BuildLog(object):
+    """BuildLog model."""
+
+    def __init__(self, data: str, metadata: dict = None):
+        """Initialize BuildLog model."""
+        self.data = data
+        self.metadata = metadata
 
 
 class BuildInfoSchema(Schema):
@@ -119,3 +119,10 @@ class BuildInfoPaginationSchema(Schema):
     total = fields.Integer(required=True)
     has_next = fields.Bool(required=False, default=False)
     has_prev = fields.Bool(required=False, default=False)
+
+
+class BuildLogSchema(Schema):
+    """BuildLog model schema."""
+
+    data = fields.String(required=True)
+    metadata = fields.Raw(required=False)

--- a/osiris/schema/build.py
+++ b/osiris/schema/build.py
@@ -2,8 +2,10 @@
 
 """Build API schema."""
 
+import re
+
 from datetime import datetime
-from typing import List
+from typing import List, Union
 
 from marshmallow import fields
 from marshmallow import post_load
@@ -13,6 +15,9 @@ from osiris import DEFAULT_OC_LOG_LEVEL
 from osiris.schema.ocp import OCP, OCPSchema
 
 from kubernetes.client.models.v1_event import V1Event as Event
+from openshift.dynamic.client import ResourceInstance
+
+from thoth.common.helpers import _DATETIME_FORMAT_STRING  # noqa
 
 
 class BuildInfo(object):
@@ -55,11 +60,37 @@ class BuildInfo(object):
             **kwargs
         )
 
+    @classmethod
+    def from_resource(cls, resource: Union[dict, ResourceInstance], build_id: str = None, **kwargs):
+        """Create BuildInfo model from kubernetes event."""
+        ocp = OCP.from_resource(resource)
+
+        metadata = resource['metadata']
+        status = resource['status']
+
+        datetime_fmt = "%Y-%m-%dT%H:%M:%SZ"
+        try:  # might be missing if build is in Pending state
+            start_ts = datetime.strptime(status['startTimestamp'], datetime_fmt)
+            end_ts = datetime.strptime(status['completionTimestamp'], datetime_fmt)
+        except KeyError:
+            start_ts = None
+            end_ts = None
+
+        return cls(
+            build_id=build_id or metadata['name'],
+            build_status=status['phase'],
+            # TODO: use `format_datetime` from thoth.common when available in PyPI
+            first_timestamp=start_ts,
+            last_timestamp=end_ts,
+            ocp_info=ocp,
+            **kwargs
+        )
+
     def build_complete(self) -> bool:
         """Return whether build has completed.
         
         Failed builds are considered completed, too."""
-        return self.build_status == 'BuildCompleted' or self.build_status == 'BuildFailed'
+        return bool(re.match(r"complete|fail", self.build_status, re.IGNORECASE))
 
 
 class BuildLog(object):
@@ -82,8 +113,8 @@ class BuildInfoSchema(Schema):
 
     ocp_info = fields.Nested(OCPSchema, required=False)
 
-    first_timestamp = fields.DateTime(required=False)
-    last_timestamp = fields.DateTime(required=False)
+    first_timestamp = fields.DateTime(required=False, format=_DATETIME_FORMAT_STRING)
+    last_timestamp = fields.DateTime(required=False, format=_DATETIME_FORMAT_STRING)
 
     log_level = fields.Integer(required=False)
 

--- a/osiris/schema/build.py
+++ b/osiris/schema/build.py
@@ -88,8 +88,9 @@ class BuildInfo(object):
 
     def build_complete(self) -> bool:
         """Return whether build has completed.
-        
-        Failed builds are considered completed, too."""
+
+        Failed builds are considered completed, too.
+        """
         return bool(re.match(r"complete|fail", self.build_status, re.IGNORECASE))
 
 

--- a/osiris/schema/build.py
+++ b/osiris/schema/build.py
@@ -14,9 +14,6 @@ from osiris.schema.ocp import OCP, OCPSchema
 
 from kubernetes.client.models.v1_event import V1Event as Event
 
-from thoth.common.helpers import _DATETIME_FORMAT_STRING
-from thoth.common.helpers import datetime2datetime_str
-
 
 class BuildLog(object):
     """BuildLog model."""

--- a/osiris/schema/config.py
+++ b/osiris/schema/config.py
@@ -15,6 +15,7 @@ class Config(object):
     def __init__(self, api_key: str, token: str, context: str = None, cluster: str = None,
                  namespace: str = None, host: str = None, port: str = None, url: str = None,
                  username: str = None, password: str = None, verify_ssl: bool = None):
+        """Initialize Config model."""
         self.api_key: str = api_key
         self.token: str = token
 

--- a/osiris/schema/ocp.py
+++ b/osiris/schema/ocp.py
@@ -2,8 +2,6 @@
 
 """OCP API schema."""
 
-from kubernetes.client.models.v1_event import V1Event as Event
-
 from marshmallow import fields
 from marshmallow import post_load
 from marshmallow import Schema
@@ -26,12 +24,29 @@ class OCP(object):
         self.self_link = self_link
 
     @classmethod
-    def from_event(cls, event: Event):
+    def from_event(cls, event: "V1Event"):
         kind = event.involved_object.kind
         name = event.involved_object.name
         namespace = event.involved_object.namespace
 
         self_link = event.metadata.self_link
+
+        return cls(
+            kind=kind,
+            name=name,
+            namespace=namespace,
+            self_link=self_link
+        )
+
+    @classmethod
+    def from_resource(cls, resource: "ResourceInstance"):
+        metadata = resource['metadata']
+
+        kind = resource['kind']
+        name = metadata['name']
+        namespace = metadata['namespace']
+
+        self_link = metadata['selfLink']
 
         return cls(
             kind=kind,

--- a/osiris/schema/ocp.py
+++ b/osiris/schema/ocp.py
@@ -15,7 +15,7 @@ class OCP(object):
                  name: str = None,
                  namespace: str = None,
                  self_link: str = None):
-
+        """Initialize OCP model."""
         self.kind = kind
 
         self.name = name
@@ -25,6 +25,7 @@ class OCP(object):
 
     @classmethod
     def from_event(cls, event: "V1Event"):
+        """Construct class from Kubernetes V1Event."""
         kind = event.involved_object.kind
         name = event.involved_object.name
         namespace = event.involved_object.namespace
@@ -40,6 +41,7 @@ class OCP(object):
 
     @classmethod
     def from_resource(cls, resource: "ResourceInstance"):
+        """Construct class from OpenShift ResourceInstance."""
         metadata = resource['metadata']
 
         kind = resource['kind']

--- a/osiris/utils.py
+++ b/osiris/utils.py
@@ -67,20 +67,3 @@ def suppress_exception(exc_type=Exception):
         return _inner
 
     return _wrapper
-
-
-def noexcept(fun: typing.Callable):
-    """Decorate non-throwing function."""
-    def _inner(*args, **kwargs):
-
-        ret = None
-        # noinspection PyBroadException
-        try:
-            ret = fun(*args, **kwargs)
-        except Exception as exc:
-            # TODO: log caught exception warnging
-            print("[WARNING] Exception caught:", exc, file=sys.stderr)
-
-        return ret
-
-    return _inner


### PR DESCRIPTION
- It is now possible to specify optional url parameter to determine how
to process received data

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   osiris/apis/build.py
modified:   osiris/schema/build.py
modified:   osiris/utils.py