### PR TITLE
Allow storing build logs only without their metadata

### DIFF
--- a/osiris/aggregator.py
+++ b/osiris/aggregator.py
@@ -93,7 +93,7 @@ class _BuildLogsAggregator(ResultStorageBase):
         ret: tuple = (build_log, )
 
         if not log_only:
-            build_info = BuildInfo(**BuildInfoSchema().load(build_doc).data)
+            build_info = BuildInfoSchema().load(build_doc).data
 
             ret = build_log, build_info
 

--- a/osiris/schema/build.py
+++ b/osiris/schema/build.py
@@ -91,7 +91,7 @@ class BuildInfo(object):
 
         Failed builds are considered completed, too.
         """
-        return bool(re.match(r"complete|fail", self.build_status, re.IGNORECASE))
+        return bool(re.match(r"complete|fail|unknown", self.build_status, re.IGNORECASE))
 
 
 class BuildLog(object):


### PR DESCRIPTION
- these will be marked as status `Unknown`
- drop unnecessary retrievals from ceph

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   osiris/aggregator.py
modified:   osiris/apis/build.py
modified:   osiris/schema/build.py